### PR TITLE
Fixing problem with lowercase and uppercase includes

### DIFF
--- a/Node.h
+++ b/Node.h
@@ -2,7 +2,7 @@
 #define _NODE_H_INCLUDED_
 #include "common.h"
 #include "EditorState.h"
-#include "Nodebox.h"
+#include "NodeBox.h"
 
 class EditorState;
 class NodeBox;

--- a/NodeBox.cpp
+++ b/NodeBox.cpp
@@ -1,4 +1,4 @@
-#include "Nodebox.h"
+#include "NodeBox.h"
 
 void NodeBox::resizeNodeBoxFace(EditorState* editor,CDR_TYPE type,vector3df position,bool both){
 	switch(type){


### PR DESCRIPTION
On Linux there is a problem at compiling at include "Nodebox.h" since it doesn't exist. 
"NodeBox.h" is the proper, uppercase version.
Fixed and compiles and runs on linux now.
