### PR TITLE
Fix MSVC compiler warnings

### DIFF
--- a/src/Editor.cpp
+++ b/src/Editor.cpp
@@ -121,9 +121,9 @@ bool Editor::run(IrrlichtDevice* irr_device, Configuration* conf,
 
 		if (state->project && state->project->GetCurrentNode()) {
 			vector3df pos = vector3df(
-				state->project->GetCurrentNode()->position.X,
-				state->project->GetCurrentNode()->position.Y,
-				state->project->GetCurrentNode()->position.Z
+				(f32)state->project->GetCurrentNode()->position.X,
+				(f32)state->project->GetCurrentNode()->position.Y,
+				(f32)state->project->GetCurrentNode()->position.Z
 			);
 			target->setPosition(pos);
 		}
@@ -351,7 +351,7 @@ void Editor::recreateCameras()
 
 	// reset matrix
 	matrix4 projMat;
-	irr::f32 orth_w = (float)ResX / (float)ResY;
+	irr::f32 orth_w = ResX / (irr::f32)ResY;
 	orth_w = 3 * orth_w;
 	projMat.buildProjectionMatrixOrthoLH(orth_w, 3, 1, 100);
 
@@ -376,10 +376,10 @@ void Editor::recreateCameras()
 			camera[i] = smgr->addCameraSceneNode(target);
 			switch(type) {
 			case VIEWT_TOP:
-				camera[i]->setPosition(vector3df(0, 2, -0.01));
+				camera[i]->setPosition(vector3df(0, 2, -0.01f));
 				break;
 			case VIEWT_BOTTOM:
-				camera[i]->setPosition(vector3df(0, -2, -0.01));
+				camera[i]->setPosition(vector3df(0, -2, -0.01f));
 				break;
 			case VIEWT_LEFT:
 				camera[i]->setPosition(vector3df(-5, 0, 0));
@@ -455,6 +455,8 @@ const char* viewportToSetting(Viewport port)
 		return "viewport_bottom_left";
 	case VIEW_BR:
 		return "viewport_bottom_right";
+	default:
+		return "viewport_top_left";
 	}
 }
 
@@ -475,6 +477,8 @@ const char* viewportTypeToSetting(ViewportType type)
 		return "left";
 	case VIEWT_BOTTOM:
 		return "bottom";
+	default:
+		return "pers";
 	}
 }
 
@@ -527,8 +531,8 @@ void Editor::viewportTick(Viewport viewport, rect<s32> rect,
 		vector2di delta = state->mouse_position;
 		delta -= viewport_drag_last;
 		viewport_drag_last = state->mouse_position;
-		viewport_offset[(int)viewport].X -= delta.X * 0.01;
-		viewport_offset[(int)viewport].Y += delta.Y * 0.01;
+		viewport_offset[(int)viewport].X -= (f32)delta.X * 0.01f;
+		viewport_offset[(int)viewport].Y += (f32)delta.Y * 0.01f;
 		if (viewport_offset[(int)viewport].X > 0.5)
 			viewport_offset[(int)viewport].X = 0.5;
 		if (viewport_offset[(int)viewport].X < -0.5)

--- a/src/FileFormat/NBE.cpp
+++ b/src/FileFormat/NBE.cpp
@@ -295,14 +295,14 @@ void NBEFileFormat::parseLine(Project * project, std::string & line)
 			node->addNodeBox();
 			node->GetCurrentNodeBox()->name = s[0];
 			node->GetCurrentNodeBox()->one = vector3df(
-				atof(s[1].c_str()),
-				atof(s[2].c_str()),
-				atof(s[3].c_str())
+				(f32)atof(s[1].c_str()),
+				(f32)atof(s[2].c_str()),
+				(f32)atof(s[3].c_str())
 			);
 			node->GetCurrentNodeBox()->two = vector3df(
-				atof(s[4].c_str()),
-				atof(s[5].c_str()),
-				atof(s[6].c_str())
+				(f32)atof(s[4].c_str()),
+				(f32)atof(s[5].c_str()),
+				(f32)atof(s[6].c_str())
 			);
 			node->remesh();
 		} else if (lower.find("end node") == 0){

--- a/src/Node.cpp
+++ b/src/Node.cpp
@@ -50,7 +50,7 @@ NodeBox* Node::GetCurrentNodeBox()
 
 NodeBox* Node::GetNodeBox(int id)
 {
-	if (id < 0 || id > boxes.size()) {
+	if (id < 0 || id > (int)boxes.size()) {
 		return NULL;
 	}
 
@@ -84,7 +84,7 @@ void Node::deleteNodebox(int id)
 
 	delete boxes[id];
 	boxes.erase(boxes.begin() + id);
-	if (GetId() >= boxes.size())
+	if (GetId() >= (int)boxes.size())
 		_selected = boxes.size() - 1;
 }
 

--- a/src/NodeBox.cpp
+++ b/src/NodeBox.cpp
@@ -152,7 +152,7 @@ void NodeBox::moveNodeBox(EditorState* editor, CDRType type, vector3df position)
 	two = new_two;
 }
 
-ITexture* darken(IVideoDriver* driver, IImage* image, float amt, const char *name)
+ITexture* darken(IVideoDriver* driver, IImage* image, f32 amt, const char *name)
 {
 	if(image == NULL)
 		return NULL;
@@ -164,9 +164,9 @@ ITexture* darken(IVideoDriver* driver, IImage* image, float amt, const char *nam
 	for(u32 y=0; y<dim.Height; y++) {
 		for(u32 x=0; x<dim.Width; x++) {
 			video::SColor c = image2->getPixel(x,y);
-			c.setRed(amt * (float)c.getRed());
-			c.setGreen(amt * (float)c.getGreen());
-			c.setBlue(amt* (float)c.getBlue());
+			c.setRed((u32)(amt * c.getRed() + 0.5f));
+			c.setGreen((u32)(amt * c.getGreen() + 0.5f));
+			c.setBlue((u32)(amt * c.getBlue() + 0.5f));
 			image2->setPixel(x, y, c);
 		}
 	}
@@ -233,14 +233,14 @@ void NodeBox::buildNode(EditorState* editor, vector3di nd_position, IrrlichtDevi
 	// Init mesh
 	SMesh * cubeMesh = new SMesh();
 
-#define x0 -0.5
-#define x1 0.5
+#define x0 -0.5f
+#define x1 0.5f
 
 	std::string lighting = editor->settings->get("lighting");
 
 	// Front face
-	vector2df topl((one.X+0.5), (-two.Y+0.5));
-	vector2df btmr((two.X+0.5), (-one.Y+0.5));
+	vector2df topl((one.X + 0.5f), (-two.Y + 0.5f));
+	vector2df btmr((two.X + 0.5f), (-one.Y + 0.5f));
 	buffer->Vertices.set_used(4);
 	buffer->Vertices[0] = video::S3DVertex(x0,x0,x0, -1,-1,-1, cubeColour, topl.X, btmr.Y);
 	buffer->Vertices[1] = video::S3DVertex(x1,x0,x0, 1,-1,-1, cubeColour, btmr.X, btmr.Y);
@@ -248,10 +248,8 @@ void NodeBox::buildNode(EditorState* editor, vector3di nd_position, IrrlichtDevi
 	buffer->Vertices[3] = video::S3DVertex(x0,x1,x0, -1, 1,-1, cubeColour, topl.X, topl.Y);
 	buffer->BoundingBox.reset(0,0,0);
 	ITexture *texture = NULL;
-	if (lighting == "2")
-		texture = darken(driver, copied[ECS_FRONT]->get(), 0.5, copied[ECS_RIGHT]->name.c_str());
-	else if (lighting == "1")
-		texture = darken(driver, copied[ECS_FRONT]->get(), 0.5, copied[ECS_RIGHT]->name.c_str());
+	if (lighting == "1" || lighting == "2")
+		texture = darken(driver, copied[ECS_FRONT]->get(), 0.5f, copied[ECS_RIGHT]->name.c_str());
 	else
 		texture = driver->addTexture(copied[ECS_FRONT]->name.c_str(), copied[ECS_FRONT]->get());
 	SMaterial mat = SMaterial();
@@ -262,8 +260,8 @@ void NodeBox::buildNode(EditorState* editor, vector3di nd_position, IrrlichtDevi
 
 
 	// Back face
-	topl = vector2df((-two.X + 0.5), (-two.Y + 0.5));
-	btmr = vector2df((-one.X + 0.5), (-one.Y + 0.5));
+	topl = vector2df((-two.X + 0.5f), (-two.Y + 0.5f));
+	btmr = vector2df((-one.X + 0.5f), (-one.Y + 0.5f));
 	buffer2->Vertices.set_used(4);
 	buffer2->Vertices[0] = video::S3DVertex(x1,x0,x1, 1, -1, 1, cubeColour, topl.X, btmr.Y);
 	buffer2->Vertices[1] = video::S3DVertex(x0,x0,x1, -1,-1, 1, cubeColour, btmr.X, btmr.Y);
@@ -271,10 +269,8 @@ void NodeBox::buildNode(EditorState* editor, vector3di nd_position, IrrlichtDevi
 	buffer2->Vertices[3] = video::S3DVertex(x1,x1,x1, 1, 1, 1, cubeColour, topl.X, topl.Y);
 	buffer2->BoundingBox.reset(0,0,0);
 	texture = NULL;
-	if (lighting == "2")
-		texture = darken(driver, copied[ECS_BACK]->get(), 0.5, copied[ECS_BACK]->name.c_str());
-	else if (lighting == "1")
-		texture = darken(driver, copied[ECS_BACK]->get(), 0.5, copied[ECS_BACK]->name.c_str());
+	if (lighting == "1" || lighting == "2")
+		texture = darken(driver, copied[ECS_BACK]->get(), 0.5f, copied[ECS_BACK]->name.c_str());
 	else
 		texture = driver->addTexture(copied[ECS_BACK]->name.c_str(), copied[ECS_BACK]->get());
 	mat = SMaterial();
@@ -285,8 +281,8 @@ void NodeBox::buildNode(EditorState* editor, vector3di nd_position, IrrlichtDevi
 
 
 	// Left face
-	topl = vector2df((-two.Z + 0.5), (-two.Y + 0.5));
-	btmr = vector2df((-one.Z + 0.5), (-one.Y + 0.5));
+	topl = vector2df((-two.Z + 0.5f), (-two.Y + 0.5f));
+	btmr = vector2df((-one.Z + 0.5f), (-one.Y + 0.5f));
 	buffer3->Vertices.set_used(4);
 	buffer3->Vertices[0] = video::S3DVertex(x0,x0,x1, -1,-1, 1, cubeColour, topl.X, btmr.Y);
 	buffer3->Vertices[1] = video::S3DVertex(x0,x0,x0, -1,-1,-1, cubeColour, btmr.X, btmr.Y);
@@ -294,10 +290,8 @@ void NodeBox::buildNode(EditorState* editor, vector3di nd_position, IrrlichtDevi
 	buffer3->Vertices[3] = video::S3DVertex(x0,x1,x1, -1, 1, 1, cubeColour, topl.X, topl.Y);
 	buffer3->BoundingBox.reset(0,0,0);
 	texture = NULL;
-	if (lighting == "2")
-		texture = darken(driver, copied[ECS_LEFT]->get(), 0.7, copied[ECS_LEFT]->name.c_str());
-	else if (lighting == "1")
-		texture = darken(driver, copied[ECS_LEFT]->get(), 0.7, copied[ECS_LEFT]->name.c_str());
+	if (lighting == "1" || lighting == "2")
+		texture = darken(driver, copied[ECS_LEFT]->get(), 0.7f, copied[ECS_LEFT]->name.c_str());
 	else
 		texture = driver->addTexture(copied[ECS_LEFT]->name.c_str(), copied[ECS_LEFT]->get());
 	mat = SMaterial();
@@ -308,8 +302,8 @@ void NodeBox::buildNode(EditorState* editor, vector3di nd_position, IrrlichtDevi
 
 
 	// Right face
-	topl = vector2df((one.Z + 0.5), (-two.Y + 0.5));
-	btmr = vector2df((two.Z + 0.5), (-one.Y + 0.5));
+	topl = vector2df((one.Z + 0.5f), (-two.Y + 0.5f));
+	btmr = vector2df((two.Z + 0.5f), (-one.Y + 0.5f));
 	buffer4->Vertices.set_used(4);
 	buffer4->Vertices[0] = video::S3DVertex(x1,x0,x0,  1,-1,-1, cubeColour, topl.X, btmr.Y);
 	buffer4->Vertices[1] = video::S3DVertex(x1,x0,x1,  1,-1, 1, cubeColour, btmr.X, btmr.Y);
@@ -317,10 +311,8 @@ void NodeBox::buildNode(EditorState* editor, vector3di nd_position, IrrlichtDevi
 	buffer4->Vertices[3] = video::S3DVertex(x1,x1,x0,  1, 1,-1, cubeColour, topl.X, topl.Y);
 	buffer4->BoundingBox.reset(0,0,0);
 	texture = NULL;
-	if (lighting == "2")
-		texture = darken(driver, copied[ECS_RIGHT]->get(), 0.7, copied[ECS_RIGHT]->name.c_str());
-	else if (lighting == "1")
-		texture = darken(driver, copied[ECS_RIGHT]->get(), 0.7, copied[ECS_RIGHT]->name.c_str());
+	if (lighting == "1" || lighting == "2")
+		texture = darken(driver, copied[ECS_RIGHT]->get(), 0.7f, copied[ECS_RIGHT]->name.c_str());
 	else
 		texture = driver->addTexture(copied[ECS_RIGHT]->name.c_str(), copied[ECS_RIGHT]->get());
 	mat = SMaterial();
@@ -331,8 +323,8 @@ void NodeBox::buildNode(EditorState* editor, vector3di nd_position, IrrlichtDevi
 
 
 	// Top face
-	topl = vector2df((one.X + 0.5), (-two.Z + 0.5));
-	btmr = vector2df((two.X + 0.5), (-one.Z + 0.5));
+	topl = vector2df((one.X + 0.5f), (-two.Z + 0.5f));
+	btmr = vector2df((two.X + 0.5f), (-one.Z + 0.5f));
 	buffer5->Vertices.set_used(4);
 	buffer5->Vertices[0] = video::S3DVertex(x0,x1,x0, -1, 1,-1, cubeColour, topl.X, btmr.Y);
 	buffer5->Vertices[1] = video::S3DVertex(x1,x1,x0,  1, 1,-1, cubeColour, btmr.X, btmr.Y);
@@ -341,7 +333,7 @@ void NodeBox::buildNode(EditorState* editor, vector3di nd_position, IrrlichtDevi
 	buffer5->BoundingBox.reset(0,0,0);
 	texture = NULL;
 	if (lighting == "1")
-		texture = darken(driver, copied[ECS_TOP]->get(), 0.7, copied[ECS_TOP]->name.c_str());
+		texture = darken(driver, copied[ECS_TOP]->get(), 0.7f, copied[ECS_TOP]->name.c_str());
 	else
 		texture = driver->addTexture(copied[ECS_TOP]->name.c_str(), copied[ECS_TOP]->get());
 	mat = SMaterial();
@@ -352,18 +344,16 @@ void NodeBox::buildNode(EditorState* editor, vector3di nd_position, IrrlichtDevi
 
 
 	// Bottom face
-	topl = vector2df((-one.X + 0.5), (-one.Z + 0.5));
-	btmr = vector2df((-two.X + 0.5), (-two.Z + 0.5));
+	topl = vector2df((-one.X + 0.5f), (-one.Z + 0.5f));
+	btmr = vector2df((-two.X + 0.5f), (-two.Z + 0.5f));
 	buffer6->Vertices.set_used(4);
 	buffer6->Vertices[0] = video::S3DVertex(x0,x0,x1, -1,-1, 1, cubeColour, topl.X, btmr.Y);
 	buffer6->Vertices[1] = video::S3DVertex(x1,x0,x1,  1,-1, 1, cubeColour, btmr.X, btmr.Y);
 	buffer6->Vertices[2] = video::S3DVertex(x1,x0,x0,  1,-1,-1, cubeColour, btmr.X, topl.Y);
 	buffer6->Vertices[3] = video::S3DVertex(x0,x0,x0, -1,-1,-1, cubeColour, topl.X, topl.Y);
 	buffer6->BoundingBox.reset(0,0,0);
-	if (lighting == "2")
-		texture = darken(driver, copied[ECS_BOTTOM]->get(), 0.4, copied[ECS_BOTTOM]->name.c_str());
-	else if (lighting == "1")
-		texture = darken(driver, copied[ECS_BOTTOM]->get(), 0.4, copied[ECS_BOTTOM]->name.c_str());
+	if (lighting == "1" || lighting == "2")
+		texture = darken(driver, copied[ECS_BOTTOM]->get(), 0.4f, copied[ECS_BOTTOM]->name.c_str());
 	else
 		texture = driver->addTexture(copied[ECS_BOTTOM]->name.c_str(), copied[ECS_BOTTOM]->get());
 	mat = SMaterial();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -91,11 +91,17 @@ int main(int argc, char *argv[]) {
 	E_DRIVER_TYPE driv = irr::video::EDT_OPENGL;
 
 	const std::string confDriver = str_to_lower(conf->get("driver"));
+#ifdef _IRR_COMPILE_WITH_DIRECT3D_8_
 	if (confDriver == "directx8") {
 		driv = EDT_DIRECT3D8;
-	} else if (confDriver == "directx9") {
+	} else
+#endif
+#ifdef _IRR_COMPILE_WITH_DIRECT3D_9_
+	if (confDriver == "directx9") {
 		driv = EDT_DIRECT3D9;
-	} else if (confDriver == "software") {
+	} else
+#endif
+	if (confDriver == "software") {
 		driv = EDT_SOFTWARE;
 	}
 

--- a/src/modes/NBEditor.cpp
+++ b/src/modes/NBEditor.cpp
@@ -326,7 +326,7 @@ void CDR::update(NBEditor* editor, bool drag, rect<s32> offset)
 		target -= offset.UpperLeftCorner;
 
 		// Get the ray
-		line3d<irr::f32> ray = smgr->getSceneCollisionManager()
+		line3d<f32> ray = smgr->getSceneCollisionManager()
 				->getRayFromScreenCoordinates(target, smgr->getActiveCamera());
 
 		// Contains the output values
@@ -345,12 +345,16 @@ void CDR::update(NBEditor* editor, bool drag, rect<s32> offset)
 				editor->state->plane_tri, wpos, tmpTri, tmpNode);
 
 		// Snapping
-		wpos -= vector3df(node->position.X, node->position.Y, node->position.Z);
+		wpos -= vector3df(
+			(f32)node->position.X, 
+			(f32)node->position.Y, 
+			(f32)node->position.Z
+		);
 
 		if (editor->state->settings->getBool("snapping")) {
-			wpos.X = floor((wpos.X + 0.5) * 16 + 0.5) / 16 - 0.5;
-			wpos.Y = floor((wpos.Y + 0.5) * 16 + 0.5) / 16 - 0.5;
-			wpos.Z = floor((wpos.Z + 0.5) * 16 + 0.5) / 16 - 0.5;
+			wpos.X = (f32)floor((wpos.X + 0.5) * 16 + 0.5) / 16 - 0.5;
+			wpos.Y = (f32)floor((wpos.Y + 0.5) * 16 + 0.5) / 16 - 0.5;
+			wpos.Z = (f32)floor((wpos.Z + 0.5) * 16 + 0.5) / 16 - 0.5;
 		}
 
 		// Do node limiting
@@ -539,7 +543,7 @@ bool NBEditor::OnEvent(const irr::SEvent &event) {
 			Node* node = state->project->GetCurrentNode();
 			if (node) {
 				int idx = node->GetId();
-				if (lb && idx < node->boxes.size() - 1){
+				if (lb && idx < (int)node->boxes.size() - 1){
 					node->select(idx + 1);
 				}
 			}
@@ -575,15 +579,19 @@ void NBEditor::updateProperties()
 	try {
 		irr::core::stringc name = prop->getElementFromId(ENB_GUI_PROP_NAME)->getText();
 		nb->name = str_replace(std::string(name.c_str(), name.size()), ' ', '_');
-		nb->one.X = wcstod(prop->getElementFromId(ENB_GUI_PROP_X1)->getText(), NULL);
-		nb->one.Y = wcstod(prop->getElementFromId(ENB_GUI_PROP_Y1)->getText(), NULL);
-		nb->one.Z = wcstod(prop->getElementFromId(ENB_GUI_PROP_Z1)->getText(), NULL);
-		nb->two.X = wcstod(prop->getElementFromId(ENB_GUI_PROP_X2)->getText(), NULL);
-		nb->two.Y = wcstod(prop->getElementFromId(ENB_GUI_PROP_Y2)->getText(), NULL);
-		nb->two.Z = wcstod(prop->getElementFromId(ENB_GUI_PROP_Z2)->getText(), NULL);
+		nb->one = vector3df(
+			(f32)wcstod(prop->getElementFromId(ENB_GUI_PROP_X1)->getText(), NULL), 
+			(f32)wcstod(prop->getElementFromId(ENB_GUI_PROP_Y1)->getText(), NULL), 
+			(f32)wcstod(prop->getElementFromId(ENB_GUI_PROP_Z1)->getText(), NULL)
+		);
+		nb->two = vector3df(
+			(f32)wcstod(prop->getElementFromId(ENB_GUI_PROP_X2)->getText(), NULL), 
+			(f32)wcstod(prop->getElementFromId(ENB_GUI_PROP_Y2)->getText(), NULL), 
+			(f32)wcstod(prop->getElementFromId(ENB_GUI_PROP_Z2)->getText(), NULL)
+		);
 		node->remesh();
 		load_ui();
-	} catch (void* e) {
+	} catch(void* e) {
 		state->device->getGUIEnvironment()->addMessageBox(L"Update failed",
 				L"Please check that the properties contain only numbers.");
 	}

--- a/src/modes/NodeEditor.cpp
+++ b/src/modes/NodeEditor.cpp
@@ -187,20 +187,20 @@ bool NodeEditor::OnEvent(const irr::SEvent &event)
 		if (event.KeyInput.Key == KEY_INSERT){
 			state->project->AddNode(state);
 			load_ui();
-		}else if (event.KeyInput.Key == KEY_DELETE){
+		} else if (event.KeyInput.Key == KEY_DELETE){
 			if (state->project->GetCurrentNode()){
 				state->project->DeleteNode(state->project->GetSelectedNodeId());
 				load_ui();
 				return true;
 			}
-		}else if (event.KeyInput.Key == KEY_DOWN){
+		} else if (event.KeyInput.Key == KEY_DOWN){
 			IGUIListBox* lb = (IGUIListBox*) state->menu->sidebar->getElementFromId(ENG_GUI_MAIN_LISTBOX);
 			int idx = state->project->GetSelectedNodeId();
-			if (lb && idx < state->project->GetNodeCount()-1){
+			if (lb && idx < (int)state->project->GetNodeCount() - 1){
 				state->project->SelectNode(idx + 1);
 				load_ui();
 			}
-		}else if (event.KeyInput.Key == KEY_UP){
+		} else if (event.KeyInput.Key == KEY_UP){
 			IGUIListBox* lb = (IGUIListBox*) state->menu->sidebar->getElementFromId(ENG_GUI_MAIN_LISTBOX);
 			int idx = state->project->GetSelectedNodeId();
 			if (lb && idx > 0){
@@ -222,7 +222,7 @@ void NodeEditor::updateProperties() {
 	try {
 		irr::core::stringc name = prop->getElementFromId(ENG_GUI_PROP_NAME)->getText();
 		node->name = str_replace(std::string(name.c_str(), name.size()), ' ', '_');
-		int y = wcstod(prop->getElementFromId(ENG_GUI_PROP_Y)->getText(), NULL);
+		int y = (int)wcstod(prop->getElementFromId(ENG_GUI_PROP_Y)->getText(), NULL);
 		if (state->settings->getBool("no_negative_node_y") && y < 0) {
 			std::list<Node*> & nodes = state->project->nodes;
 			for (std::list<Node*>::const_iterator it = nodes.begin();


### PR DESCRIPTION
NBE is not yet compatible with Irrlicht 1.9.0 (in-developement version) but this would prevent an error about direct3d8. It got removed in the latest Irrlicht version (due lack of maintenance)